### PR TITLE
fix result.GroupBy

### DIFF
--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -90,5 +90,9 @@ func (d *Datasource) QueryOverride(ctx context.Context, apl string, options ...q
 		return nil, err
 	}
 
+	// For compatibility, we must also match this behavior:
+	// https://github.com/axiomhq/axiom-go/blob/59f0e2fe1fb5008403b1e365329d9d528096d02e/axiom/datasets.go#L170
+	res.GroupBy = res.LegacyRequest.GroupBy
+
 	return &res, nil
 }

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -145,12 +145,10 @@ func buildFrameSeries(result *axiQuery.Result) *data.Frame {
 		data.NewField("_time", nil, []time.Time{}),
 	}
 
-	groups := make([]string, 0, len(result.Buckets.Totals[0].Group))
 	for group := range result.Buckets.Totals[0].Group {
 		fields = append(fields,
 			data.NewField(group, nil, []string{}),
 		)
-		groups = append(groups, group)
 	}
 
 	for _, agg := range result.Buckets.Totals[0].Aggregations {
@@ -166,7 +164,7 @@ func buildFrameSeries(result *axiQuery.Result) *data.Frame {
 		for _, g := range series.Groups {
 			values := make([]any, 0, 1+len(g.Group)+len(g.Aggregations)) // +1 for time
 			values = append(values, series.StartTime)
-			for _, field := range groups {
+			for _, field := range result.GroupBy {
 				v := g.Group[field]
 				// convert v to string regardless of type
 				strV := fmt.Sprintf("%v", v)


### PR DESCRIPTION
My previous PR which introduced a wrapper around the axiom-go query method introduced a bug.  The result.GroupBy field was not getting populated.  This fix restores the correct values in GroupBy.

Also I undid the extra workaround added by Seif.