### PR TITLE
encourage grafana to use table view for filter queries

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -228,7 +228,7 @@ func buildFrameTotals(result *axiQuery.Result) *data.Frame {
 
 func buildFrameMatches(result *AplQueryResponse) *data.Frame {
 	frame := data.NewFrame("response").SetMeta(&data.FrameMeta{
-		PreferredVisualization: data.VisTypeLogs,
+		PreferredVisualization: data.VisTypeTable,
 	})
 
 	// define fields


### PR DESCRIPTION
New users of the plugin often start out in the Explore view of Grafana.  Previously when you ran a filter query (`... | take 5`) you would get the logs panel.  Unfortunately, the Logs panel in Grafana is rather particular about the data format, and using the Table panel provides a much better experience by showing all the columns returned.

<img width="1504" alt="Screen Shot 2023-05-23 at 10 39 57 AM" src="https://github.com/axiomhq/axiom-grafana/assets/298143/74d501d2-55e1-4d8c-956f-07b72951f8f0">
