### PR TITLE
chore: enable overriding the default api host

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -82,23 +82,19 @@ export function ConfigEditor(props: Props) {
         />
       </InlineField>
       <br />
-      { window.location.hostname === 'localhost' ? ( 
-        <div>
-          <Label description="The Axiom host to use. Leave the default value if you are not using a self-hosted Axiom instance.">
-            <h6>Axiom Host</h6>
-          </Label>
-          <InlineField label="URL" labelWidth={17}>
-            <Input
-              onChange={onHostChange}
-              value={jsonData.apiHost || 'https://api.axiom.co'}
-              placeholder="axiom host"
-              width={40}
-            />
-          </InlineField>
-        </div>
-      ) : (
-        ''
-      )}
+      <div>
+        <Label description="The Axiom host to use. Leave the default value if you are not using a self-hosted Axiom instance.">
+          <h6>Axiom Host</h6>
+        </Label>
+        <InlineField label="URL" labelWidth={17}>
+          <Input
+            onChange={onHostChange}
+            value={jsonData.apiHost || 'https://api.axiom.co'}
+            placeholder="axiom host"
+            width={40}
+          />
+        </InlineField>
+      </div>
     </div>
   );
 }

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -82,19 +82,23 @@ export function ConfigEditor(props: Props) {
         />
       </InlineField>
       <br />
-      <div>
-        <Label description="The Axiom host to use. Leave the default value if you are not using a self-hosted Axiom instance.">
-          <h6>Axiom Host</h6>
-        </Label>
-        <InlineField label="URL" labelWidth={17}>
-          <Input
-            onChange={onHostChange}
-            value={jsonData.apiHost || 'https://api.axiom.co'}
-            placeholder="axiom host"
-            width={40}
-          />
-        </InlineField>
-      </div>
+      { window.location.hostname === 'localhost' || window.location.hostname.endsWith('axiomtestlabs.co') ? (
+        <div>
+          <Label description="The Axiom host to use. Leave the default value if you are not using a self-hosted Axiom instance.">
+            <h6>Axiom Host</h6>
+          </Label>
+          <InlineField label="URL" labelWidth={17}>
+            <Input
+              onChange={onHostChange}
+              value={jsonData.apiHost || 'https://api.axiom.co'}
+              placeholder="axiom host"
+              width={40}
+            />
+          </InlineField>
+        </div>
+      ) : (
+        ''
+      )}
     </div>
   );
 }


### PR DESCRIPTION
If we are using axiom grafana datasource in watchtower.dev.axiomtestlabs.co without this PR, we won't be able to hit api.dev.axiomtestlabs.co