### PR TITLE
chore: omit query request if apl is empty

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -129,6 +129,10 @@ func (d *Datasource) query(ctx context.Context, host string, pCtx backend.Plugin
 		return d.schemaLookup(ctx)
 	}
 
+	if qm.APL == "" {
+		return backend.DataResponse{}
+	}
+
 	// make request to axiom
 	result, err := d.QueryOverride(ctx, qm.APL, axiQuery.SetStartTime(query.TimeRange.From), axiQuery.SetEndTime(query.TimeRange.To))
 	if err != nil {


### PR DESCRIPTION
Creating a new panel with axiom datasource always show this error
![image](https://github.com/axiomhq/axiom-grafana/assets/20487138/358ad08d-b55c-4d8a-8039-fc663a868a5c)

that's because when creating new panel, grafana automatically send query request even if the user didn't input any APL query.

This PR will check if APL is empty and just return empty response instead of querying the host