### PR TITLE
docs: update README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -7,4 +7,40 @@ The Grafana data source plugin is the easiest way to query event data from Axiom
 This plugin has the following requirements:
 
 - An Axiom account
-- An Axiom API token with query permissions for desired datasets
+- An Axiom [personal access token](https://axiom.co/docs/reference/settings#personal-token)
+
+## Configuration
+
+1. Add a new data source in Grafana
+2. Select the Axiom data source plugin
+3. Enter your Axiom personal access token and organization ID
+4. Save and test the data source
+
+## Visualizing data
+
+The Axiom data source plugin provides a custom editor to query and visualize event data from Axiom.
+
+1. Create a new panel in Grafana
+2. Select the Axiom data source
+3. Use the query editor to filter, transform and analyze your data
+
+## Installation
+
+### Installation on Grafana Cloud
+
+For more information, visit the docs on [plugin installation](https://grafana.com/docs/grafana/latest/plugins/installation/).
+
+### Installation with Grafana CLI
+
+```
+grafana-cli plugins install axiomhq-axiom-datasource
+```
+
+### Installation with Docker
+
+1. Add the plugin to your `docker-compose.yml` or `Dockerfile`
+2. Set the environment variable `GF_INSTALL_PLUGINS` to include the plugin
+
+```
+GF_INSTALL_PLUGINS="axiomhq-axiom-datasource"
+```


### PR DESCRIPTION
`README` in root directory is unused by Grafana, so this migrates relevant pieces to the `src/README` file and updates token references to be explicit about personal access tokens.

Have not migrated the screenshot from root since that should be included from `screenshots` field of `plugin.json`