### PR TITLE
fix: clean string if it contains double slashes

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -268,15 +268,23 @@ func buildFrameMatches(result *AplQueryResponse) *data.Frame {
 		PreferredVisualization: data.VisTypeTable,
 	})
 
+	var fields []*data.Field
+
 	// define fields
 	for _, proj := range result.LegacyRequest.Projections {
 		switch proj.Alias {
 		case "_time", "_sysTime":
-			frame.Fields = append(frame.Fields, data.NewField(proj.Alias, nil, []time.Time{}))
+			fields = append(fields, data.NewField(proj.Alias, nil, []time.Time{}))
 		default:
-			frame.Fields = append(frame.Fields, data.NewField(proj.Alias, nil, []string{}))
+			if strings.Contains(proj.Alias, "\\") {
+				proj.Alias = strings.Replace(proj.Alias, "\\", "", -1)
+			}
+
+			fields = append(fields, data.NewField(proj.Alias, nil, []string{}))
 		}
 	}
+
+	frame.Fields = fields
 
 	for _, match := range result.Matches {
 		// convert structure to map of field values


### PR DESCRIPTION
**Running query like**
```
['k8s-logs-prod']
| limit 1
```
over the last year,


will fail with the following error
<img width="352" alt="image" src="https://github.com/axiomhq/axiom-grafana/assets/20487138/407e3c77-c754-488a-ae1b-dfb134b5ad2a">

**omitting this column by doing**
```
['k8s-logs-prod']
| project-away  ['data.client\\.id']
| limit 1
```
will work as expected

after debugging I found out that this is the response coming from the API
```
{
    ...
    "matches": [
        {
            ...
            "data": {
                "data": {
                    "client.id": null
                }
            }
        },
    ],
    "request": {
        ...
        "project": [
            {
                "field": "data.client\\.id",
                "alias": "data.client\\.id"
            }
        ],
        ...
    },
    ...
}
```

even in the frontend, it looks weird, probably a bug in the response
<img width="163" alt="image" src="https://github.com/axiomhq/axiom-grafana/assets/20487138/175f350e-701e-40a8-9f4c-505274deb24a">

Might be the cause to what's happening to Aptos
