### PR TITLE
Display matches as logs instead of table

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -280,7 +280,7 @@ func buildFrameTotals(result *axiQuery.Result) *data.Frame {
 
 func buildFrameMatches(result *AplQueryResponse) *data.Frame {
 	frame := data.NewFrame("response").SetMeta(&data.FrameMeta{
-		PreferredVisualization: data.VisTypeTable,
+		PreferredVisualization: data.VisTypeLogs,
 	})
 
 	// define fields


### PR DESCRIPTION
Draft because I don't love the `This datasource does not support full-range histograms.` notice seen here:

<img width="1671" alt="CleanShot 2023-06-29 at 14 32 38@2x" src="https://github.com/axiomhq/axiom-grafana/assets/1725839/f0806010-0811-41df-ae18-913e92147b12">
