### PR TITLE
fix: Run queries concurrently to speed up panels with many queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/axiomhq/axiom-go v0.15.1
 	github.com/grafana/grafana-plugin-sdk-go v0.161.0
+	github.com/stretchr/testify v1.8.2
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/chromedp/cdproto v0.0.0-20220208224320-6efb837e6bc2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
@@ -55,6 +57,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -332,6 +332,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -3,9 +3,11 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/axiomhq/axiom-go/axiom/query"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"testing"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -17,17 +19,19 @@ func TestQueryData(t *testing.T) {
 		context.Background(),
 		&backend.QueryDataRequest{
 			Queries: []backend.DataQuery{
-				{RefID: "A"},
+				{RefID: "A", JSON: json.RawMessage(`{}`)},
+				{RefID: "B", JSON: json.RawMessage(`{}`)},
+				{RefID: "C", JSON: json.RawMessage(`{}`)},
 			},
 		},
 	)
-	if err != nil {
-		t.Error(err)
+	require.NoError(t, err)
+
+	for _, res := range resp.Responses {
+		require.NoError(t, res.Error)
 	}
 
-	if len(resp.Responses) != 1 {
-		t.Fatal("QueryData must return a response")
-	}
+	require.Len(t, resp.Responses, 3, "QueryData must return a response for each query")
 }
 
 func TestBuildFrame(t *testing.T) {
@@ -47,14 +51,10 @@ func TestBuildFrame(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var queryRes query.Result
 			err := json.Unmarshal([]byte(test.aplResponse), &queryRes)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			var f any
 			err = json.Unmarshal([]byte(test.aplResponse), &f)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			grpByArr := f.(map[string]any)["request"].(map[string]any)["groupBy"].([]any)
 			queryResGrpBy := make([]string, 0, len(grpByArr))


### PR DESCRIPTION
When a panel has multiple Axiom queries in it, refreshing data takes a long time: 
![image](https://github.com/axiomhq/axiom-grafana/assets/10719325/6d88f87b-1a3d-488c-ad10-c4abae4b3b1e)

This helps by running up to 10 queries at a time.