### PR TITLE
document explicit migration path for edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Breaking changes
 
 - Personal tokens are no longer allowed; datasource authentication now requires API tokens.
-- `Edge URL` is now required in the plugin config and is used for all query operations. Existing v0.6.x data sources that only have `apiHost` and an API token must be edited after upgrade to set **Edge URL**. For provisioned data sources, add `jsonData.edgeURL`; legacy `jsonData.edge` values continue to be migrated automatically.
+- `Edge URL` is now required in the plugin config and is used for all query operations. To preserve compatibility for existing v0.6.x data sources that only have `apiHost` and an API token, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` when neither `edge` nor `edgeURL` is configured. Users with a different edge endpoint should update the datasource setting or set `jsonData.edgeURL` in provisioning. Legacy `jsonData.edge` values continue to be migrated automatically.
 
 ## 0.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Breaking changes
 
-- Personal tokens are no longer allowed; datasource authentication now requires API tokens.
+- Personal tokens are no longer allowed; datasource authentication now requires API tokens. Existing data sources that still use a Personal token with Org ID must be updated to use an API token before upgrading, otherwise dashboards backed by those data sources will fail authentication after upgrade.
 - `Edge URL` is now required in the plugin config and is used for all query operations. To preserve compatibility for existing v0.6.x data sources that only have `apiHost` and an API token, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` when neither `edge` nor `edgeURL` is configured. Users with a different edge endpoint should update the datasource setting or set `jsonData.edgeURL` in provisioning. Legacy `jsonData.edge` values continue to be migrated automatically.
 
 ## 0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Breaking changes
 
 - Personal tokens are no longer allowed; datasource authentication now requires API tokens.
-- `Edge URL` is now required in the plugin config and is used for all query operations.
+- `Edge URL` is now required in the plugin config and is used for all query operations. Existing v0.6.x data sources that only have `apiHost` and an API token must be edited after upgrade to set **Edge URL**. For provisioned data sources, add `jsonData.edgeURL`; legacy `jsonData.edge` values continue to be migrated automatically.
 
 ## 0.6.4
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,29 @@ GF_INSTALL_PLUGINS="axiomhq-axiom-datasource"
 
 1. Add a new data source in Grafana.
 2. Select the "Axiom" data source type.
-3. Enter your Axiom read-only API Token.
-4. Save and test the data source.
+3. Enter your Axiom API token.
+4. Enter the Edge URL for your Axiom deployment.
+5. Save and test the data source.
+
+### Upgrading from v0.6.x to v0.7.0
+
+v0.7.0 requires an Edge URL for query operations. Existing data sources that only have an API URL and API token must be updated before queries will run successfully.
+
+To migrate an existing data source:
+
+1. In Grafana, open **Connections > Data sources > Axiom**.
+2. Set **Edge URL** to the edge endpoint for your Axiom deployment, for example `https://us-east-1.aws.edge.axiom.co`.
+3. Save and test the data source.
+
+If the data source is provisioned, add `edgeURL` under `jsonData`:
+
+```yaml
+jsonData:
+  apiHost: https://api.axiom.co
+  edgeURL: https://us-east-1.aws.edge.axiom.co
+```
+
+Data sources that already used the legacy `edge` setting continue to be migrated automatically to `edgeURL`.
 
 ## Query Editor
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ GF_INSTALL_PLUGINS="axiomhq-axiom-datasource"
 
 ### Upgrading from v0.6.x to v0.7.0
 
+v0.7.0 no longer supports Personal token plus Org ID authentication. If an existing data source still uses a Personal token and Org ID, update it to use an Axiom API token before upgrading so dashboards using that data source continue to authenticate.
+
 v0.7.0 uses Edge URL for query operations. Existing v0.6.x data sources that only have an API URL and API token continue to work: when neither `edge` nor `edgeURL` is configured, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` at config load.
 
 No manual migration is required for data sources that should use the default edge endpoint. If your Axiom deployment uses a different edge endpoint, update the data source:

--- a/README.md
+++ b/README.md
@@ -35,25 +35,25 @@ GF_INSTALL_PLUGINS="axiomhq-axiom-datasource"
 1. Add a new data source in Grafana.
 2. Select the "Axiom" data source type.
 3. Enter your Axiom API token.
-4. Enter the Edge URL for your Axiom deployment.
+4. Confirm the Edge URL for your Axiom deployment. The default is `https://us-east-1.aws.edge.axiom.co`.
 5. Save and test the data source.
 
 ### Upgrading from v0.6.x to v0.7.0
 
-v0.7.0 requires an Edge URL for query operations. Existing data sources that only have an API URL and API token must be updated before queries will run successfully.
+v0.7.0 uses Edge URL for query operations. Existing v0.6.x data sources that only have an API URL and API token continue to work: when neither `edge` nor `edgeURL` is configured, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` at config load.
 
-To migrate an existing data source:
+No manual migration is required for data sources that should use the default edge endpoint. If your Axiom deployment uses a different edge endpoint, update the data source:
 
 1. In Grafana, open **Connections > Data sources > Axiom**.
-2. Set **Edge URL** to the edge endpoint for your Axiom deployment, for example `https://us-east-1.aws.edge.axiom.co`.
+2. Set **Edge URL** to the edge endpoint for your Axiom deployment.
 3. Save and test the data source.
 
-If the data source is provisioned, add `edgeURL` under `jsonData`:
+If the data source is provisioned and should use a non-default edge endpoint, add `edgeURL` under `jsonData`:
 
 ```yaml
 jsonData:
   apiHost: https://api.axiom.co
-  edgeURL: https://us-east-1.aws.edge.axiom.co
+  edgeURL: https://your-edge.example.com
 ```
 
 Data sources that already used the legacy `edge` setting continue to be migrated automatically to `edgeURL`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,5 +71,6 @@ func resolveEdgeUrl(edge string, edgeUrl string) (string, error) {
 		return fmt.Sprintf("https://%s", edge), nil
 	}
 
-	return "", fmt.Errorf("Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.")
+	return "https://us-east-1.aws.edge.axiom.co", nil
+	// return "", fmt.Errorf("Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,9 +19,9 @@ func TestResolveBaseURL(t *testing.T) {
 		err      string
 	}{
 		{
-			name:    "no edge - returns error",
-			apiHost: "https://api.axiom.co",
-			err:     "Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.",
+			name:     "no edge - defaults to us east edge",
+			apiHost:  "https://api.axiom.co",
+			expected: "https://us-east-1.aws.edge.axiom.co",
 		},
 		{
 			name:     "edge domain",
@@ -59,9 +59,9 @@ func TestResolveBaseURL(t *testing.T) {
 			expected: "https://primary.edge.axiom.co",
 		},
 		{
-			name:    "legacy EU instance - no edge returns error",
-			apiHost: "https://api.eu.axiom.co",
-			err:     "Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.",
+			name:     "legacy EU instance - no edge defaults to us east edge",
+			apiHost:  "https://api.eu.axiom.co",
+			expected: "https://us-east-1.aws.edge.axiom.co",
 		},
 		{
 			name:     "staging edge domain",
@@ -69,8 +69,8 @@ func TestResolveBaseURL(t *testing.T) {
 			expected: "https://us-east-1.edge.staging.axiomdomain.co",
 		},
 		{
-			name: "no apiHost, no edge - returns error",
-			err:  "Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.",
+			name:     "no apiHost, no edge - defaults to us east edge",
+			expected: "https://us-east-1.aws.edge.axiom.co",
 		},
 	}
 
@@ -118,7 +118,7 @@ func TestParseConfigFallsBackToLegacyEdgeDomain(t *testing.T) {
 	require.Equal(t, "https://eu-central-1.aws.edge.axiom.co", cfg.EdgeURL)
 }
 
-func TestParseConfigRequiresEdgeURL(t *testing.T) {
+func TestParseConfigDefaultsEdgeURL(t *testing.T) {
 	settings := backend.DataSourceInstanceSettings{
 		JSONData: json.RawMessage(`{
 			"apiHost": "https://api.axiom.co"
@@ -127,6 +127,6 @@ func TestParseConfigRequiresEdgeURL(t *testing.T) {
 
 	cfg, err := ParseConfig(context.Background(), settings)
 
-	require.Nil(t, cfg)
-	require.EqualError(t, err, "Edge URL is required. Please configure the Edge URL in the Axiom Grafana datasource settings.")
+	require.NoError(t, err)
+	require.Equal(t, "https://us-east-1.aws.edge.axiom.co", cfg.EdgeURL)
 }

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -57,8 +57,8 @@ func (d *Datasource) handleDatasetMetrics(w http.ResponseWriter, r *http.Request
 
 	dsf, err := d.api.GetMetricsForDataset(r.Context(), dataset, startTime, endTime)
 	if err != nil {
-		logger.Error("error looking up schema", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("looking up dataset schema failed", "error", err.Error())
+		http.Error(w, "Failed to lookup dataset schema", http.StatusInternalServerError)
 		return
 	}
 
@@ -73,8 +73,8 @@ func (d *Datasource) handleDatasetTags(w http.ResponseWriter, r *http.Request) {
 
 	dsf, err := d.api.GetMetricTags(r.Context(), dataset, "", startTime, endTime)
 	if err != nil {
-		logger.Error("error looking up schema", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("failed to fetch dataset tags", "error", err.Error())
+		http.Error(w, "Failed to fetch dataset tags", http.StatusInternalServerError)
 		return
 	}
 
@@ -90,8 +90,8 @@ func (d *Datasource) handleDatasetTagValues(w http.ResponseWriter, r *http.Reque
 
 	values, err := d.api.GetMetricTagValues(r.Context(), dataset, "", tag, startTime, endTime)
 	if err != nil {
-		logger.Error("error looking up tag values", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("fetching tag values failed", "error", err.Error())
+		http.Error(w, "Failed to fetch tag values", http.StatusInternalServerError)
 		return
 	}
 
@@ -107,8 +107,8 @@ func (d *Datasource) handleMetricTags(w http.ResponseWriter, r *http.Request) {
 
 	dsf, err := d.api.GetMetricTags(r.Context(), dataset, metric, startTime, endTime)
 	if err != nil {
-		logger.Error("error looking up schema", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("fetching metric tags failed", "error", err.Error())
+		http.Error(w, "Failed to fetch metric tags", http.StatusInternalServerError)
 		return
 	}
 
@@ -125,8 +125,8 @@ func (d *Datasource) handleMetricTagValues(w http.ResponseWriter, r *http.Reques
 
 	values, err := d.api.GetMetricTagValues(r.Context(), dataset, metric, tag, startTime, endTime)
 	if err != nil {
-		logger.Error("error looking up tag values", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("fetching metric tag values failed", "error", err.Error())
+		http.Error(w, "Failed to fetch metric tag values", http.StatusInternalServerError)
 		return
 	}
 
@@ -136,8 +136,8 @@ func (d *Datasource) handleMetricTagValues(w http.ResponseWriter, r *http.Reques
 func writeJSON(w http.ResponseWriter, logger log.Logger, value any) {
 	j, err := json.Marshal(value)
 	if err != nil {
-		logger.Error("error marshaling json", "error", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("failed to marshal response JSON", "error", err.Error())
+		http.Error(w, "Failed to marshal JSON", http.StatusInternalServerError)
 		return
 	}
 

--- a/provisioning/dashboards/axiom-play.json
+++ b/provisioning/dashboards/axiom-play.json
@@ -105,7 +105,7 @@
       },
       "targets": [
         {
-          "query": "['hn']\n| summarize count() by bin_auto(_time)",
+          "query": "['otel-demo-logs']\n| summarize count() by bin_auto(_time)",
           "kind": "apl",
           "version": 2.0,
           "datasource": {
@@ -115,7 +115,7 @@
           "refId": "A"
         }
       ],
-      "title": "hn posts",
+      "title": "logs over time",
       "type": "timeseries"
     }
   ],
@@ -126,7 +126,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -4,9 +4,11 @@ datasources:
   - name: 'Axiom'
     type: 'axiomhq-axiom-datasource'
     access: proxy
-    isDefault: false
+    isDefault: true
     orgId: 1
-    version: 1
+    version: 2
     editable: true
     jsonData:
       path: '/resources'
+      apiHost: https://api.axiom.co
+      edgeURL: https://us-east-1.aws.edge.axiom.co

--- a/src/README.md
+++ b/src/README.md
@@ -19,6 +19,8 @@ This plugin has the following requirements:
 
 ## Upgrading from v0.6.x to v0.7.0
 
+v0.7.0 no longer supports Personal token plus Org ID authentication. If an existing data source still uses a Personal token and Org ID, update it to use an Axiom API token before upgrading so dashboards using that data source continue to authenticate.
+
 v0.7.0 uses Edge URL for query operations. Existing v0.6.x data sources that only have an API URL and API token continue to work: when neither `edge` nor `edgeURL` is configured, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` at config load.
 
 No manual migration is required for data sources that should use the default edge endpoint. If your Axiom deployment uses a different edge endpoint, update the data source:

--- a/src/README.md
+++ b/src/README.md
@@ -14,25 +14,25 @@ This plugin has the following requirements:
 1. Add a new data source in Grafana
 2. Select the Axiom data source plugin
 3. Enter your Axiom advanced API token
-4. Enter the Edge URL for your Axiom deployment
+4. Confirm the Edge URL for your Axiom deployment. The default is `https://us-east-1.aws.edge.axiom.co`
 5. Save and test the data source
 
 ## Upgrading from v0.6.x to v0.7.0
 
-v0.7.0 requires an Edge URL for query operations. Existing data sources that only have an API URL and API token must be updated before queries will run successfully.
+v0.7.0 uses Edge URL for query operations. Existing v0.6.x data sources that only have an API URL and API token continue to work: when neither `edge` nor `edgeURL` is configured, the plugin defaults `edgeURL` to `https://us-east-1.aws.edge.axiom.co` at config load.
 
-To migrate an existing data source:
+No manual migration is required for data sources that should use the default edge endpoint. If your Axiom deployment uses a different edge endpoint, update the data source:
 
 1. In Grafana, open **Connections > Data sources > Axiom**
-2. Set **Edge URL** to the edge endpoint for your Axiom deployment, for example `https://us-east-1.aws.edge.axiom.co`
+2. Set **Edge URL** to the edge endpoint for your Axiom deployment
 3. Save and test the data source
 
-If the data source is provisioned, add `edgeURL` under `jsonData`:
+If the data source is provisioned and should use a non-default edge endpoint, add `edgeURL` under `jsonData`:
 
 ```yaml
 jsonData:
   apiHost: https://api.axiom.co
-  edgeURL: https://us-east-1.aws.edge.axiom.co
+  edgeURL: https://your-edge.example.com
 ```
 
 Data sources that already used the legacy `edge` setting continue to be migrated automatically to `edgeURL`.

--- a/src/README.md
+++ b/src/README.md
@@ -14,7 +14,28 @@ This plugin has the following requirements:
 1. Add a new data source in Grafana
 2. Select the Axiom data source plugin
 3. Enter your Axiom advanced API token
-4. Save and test the data source
+4. Enter the Edge URL for your Axiom deployment
+5. Save and test the data source
+
+## Upgrading from v0.6.x to v0.7.0
+
+v0.7.0 requires an Edge URL for query operations. Existing data sources that only have an API URL and API token must be updated before queries will run successfully.
+
+To migrate an existing data source:
+
+1. In Grafana, open **Connections > Data sources > Axiom**
+2. Set **Edge URL** to the edge endpoint for your Axiom deployment, for example `https://us-east-1.aws.edge.axiom.co`
+3. Save and test the data source
+
+If the data source is provisioned, add `edgeURL` under `jsonData`:
+
+```yaml
+jsonData:
+  apiHost: https://api.axiom.co
+  edgeURL: https://us-east-1.aws.edge.axiom.co
+```
+
+Data sources that already used the legacy `edge` setting continue to be migrated automatically to `edgeURL`.
 
 ## Visualizing data
 

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -23,9 +23,7 @@ export function ConfigEditor(props: Props) {
   const { onOptionsChange, options } = props;
   const jsonData = useMemo(() => (options.jsonData || {}) as AxiomDataSourceOptions, [options.jsonData]);
   const secureJsonData = (options.secureJsonData || {}) as MySecureJsonData;
-  const [shouldShowOrgId, setShowOrgId] = useState(
-    !!options.jsonData.orgID && options.secureJsonData?.accessToken.startsWith('xapt-')
-  );
+  const [isPersonalToken, setIsPersonalToken] = useState(options.secureJsonData?.accessToken.startsWith('xapt-'));
 
   useEffect(() => {
     const migratedEdgeURL = jsonData.edgeURL || (jsonData.edge ? legacyEdgeToEdgeURL(jsonData.edge) : '');
@@ -64,9 +62,10 @@ export function ConfigEditor(props: Props) {
   // Secure field (only sent to the backend)
   const onAccessTokenChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.value.startsWith('xapt-')) {
-      setShowOrgId(true);
+      setIsPersonalToken(true);
+      return;
     } else {
-      setShowOrgId(false);
+      setIsPersonalToken(false);
     }
 
     onOptionsChange({
@@ -91,14 +90,6 @@ export function ConfigEditor(props: Props) {
     });
   };
 
-  const onOrgIDChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const jsonData = {
-      ...options.jsonData,
-      orgID: event.target.value,
-    };
-    onOptionsChange({ ...options, jsonData });
-  };
-
   const { secureJsonFields } = options;
   return (
     <div className="gf-form-group">
@@ -116,21 +107,15 @@ export function ConfigEditor(props: Props) {
         />
       </InlineField>
       <br />
-      {/* Only show orgId for users who have already set it. Promote advanced tokens instead */}
-      {shouldShowOrgId && (
-        <InlineField label="Org ID" labelWidth={17}>
-          <Input value={jsonData.orgID || ''} placeholder="" width={40} onChange={onOrgIDChange} />
-        </InlineField>
-      )}
-      {/* If orgId is set, show a deprecation message */}
-      {shouldShowOrgId && (
+      {/* If personal token is used, show an error message */}
+      {isPersonalToken && (
         <div>
           <Alert
-            title="Personal tokens are deprecated and will be removed in the next release. Please switch to advanced API tokens."
+            title="Personal tokens are deprecated. Please switch to advanced API tokens."
             about="Token"
-            severity="warning"
+            severity="error"
             buttonContent="Learn more"
-            topSpacing={4}
+            topSpacing={0}
           />
         </div>
       )}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,7 +55,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5",
+    "grafanaDependency": ">=11.6.11",
     "plugins": []
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ export const DEFAULT_QUERY: Partial<AxiomQuery> = {
  */
 export interface AxiomDataSourceOptions extends DataSourceJsonData {
   apiHost: string;
-  orgID: string;
   /**
    * Legacy regional edge domain for ingest and query operations.
    * Kept for migrating existing datasource settings to edgeURL.


### PR DESCRIPTION
- update the config backend to provide a default url for edgeURL so we avoid a breaking change
- fix minimum Grafana version in plugin.json
- provide edgeURL for the provisioned chart and switch dataset to otel-demo-logs as hn dataset doesn't seem to have events anymore
- completely removed the orgId fied